### PR TITLE
fix: remove unused submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,9 +12,6 @@
 	path = tests/cfo/deps/stake
 	url = https://github.com/project-serum/stake.git
 	branch = armani/cfo
-[submodule "examples/permissioned-markets/deps/serum-dex"]
-	path = tests/permissioned-markets/deps/serum-dex
-	url = https://github.com/project-serum/serum-dex
 [submodule "tests/auction-house"]
 	path = tests/auction-house
 	url = https://github.com/armaniferrante/auction-house


### PR DESCRIPTION
In our build system we get errors about the following path not existing despite being listed in `.gitmodules`. It looks like it might have been previously removed from the repo without updating the `.gitmodules` file?